### PR TITLE
update Trusting a Custom Certificate Authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,7 +813,22 @@ spec:
   bundle_cacert_secret: <resourcename>-custom-certs
 ```
 
-To create the secrets, you can use the commands below:
+Create the secret with `kustomization.yaml` file:
+
+```yaml
+....
+
+secretGenerator:
+  - name: <resourcename>-custom-certs
+    files:
+      - bundle-ca.crt=<path+filename>
+    options:
+      disableNameSuffixHash: true
+      
+...
+```
+
+Create the secret with CLI:
 
 * Certificate Authority secret
 


### PR DESCRIPTION


##### SUMMARY
Add custom certificate bundle using the Kustomize file instead of the CLI. The readme only referes to the CLI command option

##### ADDITIONAL INFORMATION
I had hard times to identify how to declare the include statement for a custom certifcate bundle within the Kustomize file.
The tricky part for me was to spot the option "disableNameSuffixHash: true" in order to avoid renaming the secret name with an has suffix


